### PR TITLE
 修正播放器過矮時出現"空心"現象

### DIFF
--- a/bilibili_adjustPlayer.user.js
+++ b/bilibili_adjustPlayer.user.js
@@ -12,7 +12,7 @@
 // @include     http*://bangumi.bilibili.com/movie/*
 // @exclude     http*://bangumi.bilibili.com/movie/
 // @description 调整B站播放器设置，增加一些实用的功能。
-// @version     1.18
+// @version     1.18.1
 // @grant       GM.setValue
 // @grant       GM_setValue
 // @grant       GM.getValue
@@ -419,6 +419,7 @@
 						'#bofqi .player, .moviescontent { width: '+ width +' !important; height: calc(48px + '+ width +' / calc('+ ratio +') - 300px / calc('+ ratio +') + 68px) !important; } ',
 						'#bofqi.wide .player, .wide.moviescontent { width: '+ width +' !important; height: calc('+ width +' / calc('+ ratio +') + 68px) !important; } ',
 						'.player-wrapper .bangumi-player, #__bofqi.bili-wrapper { width: '+ width +' !important; background: none !important; height: auto !important;} ',
+						'#bangumi_player.player-wrapper, #__bofqi.bili-wrapper { min-height: unset !important;} ',
 						'#bofqi.wide .autohide-controlbar, .wide.autohide-controlbar-movies { width: '+ width +' !important; height: calc('+ width +' / calc('+ ratio +') + 0px) !important; } '
 					];
 					var node = document.createElement('style');


### PR DESCRIPTION
如果播放器設置過矮時
會出現如下圖的"空心"現象
投稿頁：
![screenshot-www bilibili com-2018 03 27-13-08-24](https://user-images.githubusercontent.com/18757629/37947924-33456ab4-31c0-11e8-92d6-b92d8c2b771f.png)
番劇頁：
![screenshot-www bilibili com-2018 03 27-13-09-04](https://user-images.githubusercontent.com/18757629/37947925-337ed7f4-31c0-11e8-95bf-631af4dbfe44.png)
此更改修正這問題
修正後如下圖
投稿頁：
![screenshot-www bilibili com-2018 03 27-13-09-35](https://user-images.githubusercontent.com/18757629/37947926-33b07bec-31c0-11e8-979e-305ab676ac6d.png)
番劇頁：
![screenshot-www bilibili com-2018 03 27-13-09-40](https://user-images.githubusercontent.com/18757629/37947927-33e1f884-31c0-11e8-9130-cdf352617511.png)