### PR TITLE
修正：重寫迷你播放器滾動事件

### DIFF
--- a/bilibili_adjustPlayer.user.js
+++ b/bilibili_adjustPlayer.user.js
@@ -12,7 +12,7 @@
 // @include     http*://bangumi.bilibili.com/movie/*
 // @exclude     http*://bangumi.bilibili.com/movie/
 // @description 调整B站播放器设置，增加一些实用的功能。
-// @version     1.26
+// @version     1.26.1
 // @grant       GM.setValue
 // @grant       GM_setValue
 // @grant       GM.getValue
@@ -607,6 +607,59 @@
 					}
 				} catch (e) {console.log('resizePlayer：'+e);}
 			}
+			var fixMiniPlayer = function() {
+				if (localStorage.getItem('adjustPlayer_b_miniplayer') === null) localStorage.setItem('adjustPlayer_b_miniplayer', localStorage.getItem('b_miniplayer'));
+				if (localStorage.getItem('adjustPlayer_b_miniplayer') !== '1' && localStorage.getItem('adjustPlayer_b_miniplayer') !== '0') localStorage.setItem('adjustPlayer_b_miniplayer', '1');
+				var miniplayer = function(type, miniSwitch) {
+					var isMiniplayer = localStorage.getItem('b_miniplayer');
+					if (type === "off") {
+						if (isMiniplayer === "1") miniSwitch.click();
+					} else if (type === "on") {
+						if (isMiniplayer === "0") miniSwitch.click();
+					}
+				};
+				var NavRight = matchURL.isNewBangumi() ? document.querySelector('.bangumi-nav-right') : document.querySelector('.fixed-nav-m');
+				if (NavRight === null) return;
+				var miniSwitch = matchURL.isNewBangumi() ? NavRight.querySelectorAll('.bangumi-nav-right > .nav-mini-switch')[0] : NavRight.querySelectorAll('.fixed-nav-m .mini')[0];
+				var setMiniPlayer = function() {
+					var adjustPlayerMiniplayer = localStorage.getItem('adjustPlayer_b_miniplayer');
+					//console.log(adjustPlayerMiniplayer);
+					if (adjustPlayerMiniplayer === "1") {
+						if (!matchURL.isNewBangumi() || window.scrollY >= document.querySelector('#bangumi_detail').offsetTop) miniplayer("on", miniSwitch);
+						else miniplayer("off", miniSwitch);
+					} else if (adjustPlayerMiniplayer === "0") miniplayer("off", miniSwitch);
+				};
+				var miniSwitchClone = miniSwitch.cloneNode(true);
+				var setMiniSwitchClone = function() {
+					setMiniPlayer();
+					var miniplayerValue = localStorage.getItem('adjustPlayer_b_miniplayer');
+					//console.log(miniplayerValue);
+					if (miniplayerValue === '0') {
+						miniSwitchClone.innerHTML = miniSwitchClone.innerHTML.replace('ON', 'OFF');
+						miniSwitchClone.title = miniSwitchClone.title.replace('关闭', '打开');
+					} else if (miniplayerValue === '1') {
+						miniSwitchClone.innerHTML = miniSwitchClone.innerHTML.replace('OFF', 'ON');
+						miniSwitchClone.title = miniSwitchClone.title.replace('打开', '关闭');
+					}
+				};
+				miniSwitchClone.onclick = function(e) {
+					var adjustPlayerMiniplayer = localStorage.getItem('adjustPlayer_b_miniplayer');
+					//console.log(adjustPlayerMiniplayer);
+					if (adjustPlayerMiniplayer === '0') localStorage.setItem('adjustPlayer_b_miniplayer', '1');
+					else if (adjustPlayerMiniplayer === '1') localStorage.setItem('adjustPlayer_b_miniplayer', '0');
+					setMiniSwitchClone();
+					return;
+				};
+				setMiniSwitchClone();
+				miniSwitch.setAttribute('style', 'display:none');
+				NavRight.insertBefore(miniSwitchClone, miniSwitch);
+				if (matchURL.isNewBangumi()) {
+					window.addEventListener('scroll', function(e) {
+						setMiniPlayer();
+					});
+				}
+			};
+			fixMiniPlayer();
 		},
 		resizeMiniPlayer: function (set,width,isResizable) {
 			if (typeof set !== 'undefined' && typeof width !== 'undefined') {


### PR DESCRIPTION
接 #4 中重寫迷你播放器滾動事件部份
由於也接近再重寫了
說一下為何要這樣寫
執行鏈是`fixMiniPlayer`->`setMiniSwitchClone`->`setMiniSwitch`->`miniplayer`
`fixMiniPlayer`是初始化部份
會調用`setMiniSwitchClone`設定Clone按鈕
`setMiniSwitchClone`會根據localStorage去設定Clone按鈕並調用`setMiniSwitch`判斷並開關迷你播放器
`setMiniSwitch`是判斷並開關迷你播放器
當localStorage中腳本的值是關閉時被調用則一律關閉迷你播放器
當localStorage中腳本的值是打開時被調用再判斷是否不是番劇頁或滾動到播放器下方
是就打開迷你播放器否則關閉迷你播放器
`miniplayer`是開關迷你播放器的函數
當Clone按鈕按下時先更改localStorage再調用`setMiniSwitchClone`重設定Clone按鈕並再調用`setMiniSwitch`判斷並開關迷你播放器
是番劇頁時會注冊Scroll事件調用`setMiniSwitch`再判斷並開關迷你播放器
無論是按按鈕還是滾動時都會執行對應函數並調用其之後的函數
確保沒有例外情況

而`fixMiniPlayer`是故意放在`adjustPlayer.resizePlayer`末端
無論`setting.resizePlayer`如何
`fixMiniPlayer`都會在`adjustPlayer.resizePlayer`執行的頁面中執行
那就不需要考慮沒執行`fixMiniPlayer`時要同步設定的問題
除非移除腳本否則不出現沒執行`fixMiniPlayer`的情況